### PR TITLE
feat(users): add investigator invitation workflow to admin

### DIFF
--- a/backend/apps/users/admin.py
+++ b/backend/apps/users/admin.py
@@ -1,15 +1,49 @@
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.shortcuts import redirect
+from django.template.response import TemplateResponse
+from django.urls import path, reverse
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
-from apps.users.models import User
+from apps.users.forms import InvestigatorInvitationForm
+from apps.users.models import OnboardingInvitation, User
+from apps.users.services import create_investigator_invitation
+
+
+@admin.register(OnboardingInvitation)
+class OnboardingInvitationAdmin(admin.ModelAdmin):
+    """
+    Admin interface for managing Onboarding Invitations.
+    Provides a read-only view into the status of invitations.
+    """
+    list_display = ('user', 'is_used', 'is_expired', 'created_at', 'expires_at', 'used_at')
+    list_filter = ('created_at', 'expires_at', 'used_at')
+    search_fields = ('user__username', 'user__email')
+    readonly_fields = ('user', 'token', 'created_at', 'updated_at', 'expires_at', 'used_at')
+
+    @admin.display(boolean=True, description="Used?")
+    def is_used(self, obj):
+        return obj.used_at is not None
+
+    @admin.display(boolean=True, description="Expired?")
+    def is_expired(self, obj):
+        return obj.is_expired()
+
+    def has_add_permission(self, request):
+        # Invitations should only be created via the User admin interface
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        # Make invitations immutable from the admin
+        return False
 
 
 @admin.register(User)
 class UserAdmin(BaseUserAdmin):
     """
-    Customized User admin to display caseworker status and public key bundle,
-    and enable searching, which is crucial for the report assignment interface.
+    Customized User admin to display caseworker status, public key bundle,
+    and add a custom action to invite a new investigator.
     """
     list_display = (
         "username",
@@ -24,10 +58,99 @@ class UserAdmin(BaseUserAdmin):
     search_fields = ("username", "first_name", "last_name", "email")
     ordering = ("username",)
 
-    # Add custom fields to the fieldsets for the user detail view
     fieldsets = BaseUserAdmin.fieldsets + (  # type: ignore
         (_("Custom Properties"), {"fields": ("is_caseworker", "public_key_bundle")}),
     )
     add_fieldsets = BaseUserAdmin.add_fieldsets + (
         (_("Custom Properties"), {"fields": ("is_caseworker",)}),
     )
+
+    def get_urls(self):
+        """Add the custom URL for the invitation view."""
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                "invite-investigator/",
+                self.admin_site.admin_view(self.invite_investigator_view),
+                name="users_user_invite_investigator",
+            )
+        ]
+        return custom_urls + urls
+
+    def changelist_view(self, request, extra_context=None):
+        """Override the changelist view to add a custom button."""
+        extra_context = extra_context or {}
+        # The URL for our custom view
+        invite_url = reverse("admin:users_user_invite_investigator")
+        # Use format_html to mark the string as safe for rendering
+        extra_context["invite_button"] = format_html(
+            '<a href="{}" class="button">Invite Investigator</a>', invite_url
+        )
+        return super().changelist_view(request, extra_context=extra_context)
+
+    def invite_investigator_view(self, request):
+        """
+        Admin view to render and process the investigator invitation form.
+        """
+        if request.method == "POST":
+            form = InvestigatorInvitationForm(request.POST)
+            if form.is_valid():
+                try:
+                    onboarding_url = create_investigator_invitation(**form.cleaned_data)
+
+                    # Success message with embedded HTML and JavaScript for a "Copy" button
+                    success_message = format_html(
+                        """
+                        <strong>SUCCESS:</strong> Invitation created for {username}.
+                        <div style="margin-top: 1rem;">
+                            <strong>Onboarding Link:</strong>
+                            <div style="display: flex; align-items: center; gap: 0.5rem; margin-top: 0.25rem;">
+                                <pre id="onboarding-link" style="margin: 0; padding: 0.5rem; border: 1px solid var(--hairline-color); background-color: var(--body-bg); white-space: pre-wrap; word-break: break-all;">{onboarding_url}</pre>
+                                <button type="button" id="copy-link-button" class="button">Copy</button>
+                            </div>
+                            <p style="margin-top: 0.5rem;">
+                                <em>Securely deliver this single-use link to the investigator.</em>
+                            </p>
+                        </div>
+                        <script>
+                            document.addEventListener('DOMContentLoaded', function() {{
+                                const copyButton = document.getElementById('copy-link-button');
+                                const linkElement = document.getElementById('onboarding-link');
+                                if (copyButton && linkElement) {{
+                                    copyButton.addEventListener('click', function() {{
+                                        navigator.clipboard.writeText(linkElement.innerText).then(function() {{
+                                            copyButton.textContent = 'Copied!';
+                                            copyButton.disabled = true;
+                                            setTimeout(function() {{
+                                                copyButton.textContent = 'Copy';
+                                                copyButton.disabled = false;
+                                            }}, 2000);
+                                        }}).catch(function(err) {{
+                                            console.error('Failed to copy text: ', err);
+                                            copyButton.textContent = 'Error';
+                                        }});
+                                    }});
+                                }}
+                            }});
+                        </script>
+                        """,
+                        username=form.cleaned_data["username"],
+                        onboarding_url=onboarding_url,
+                    )
+                    self.message_user(request, success_message, messages.SUCCESS)
+
+                    return redirect("admin:users_user_changelist")
+                except ValueError as e:
+                    self.message_user(request, f"Error: {e}", messages.ERROR)
+        else:
+            form = InvestigatorInvitationForm()
+
+        context = {
+            **self.admin_site.each_context(request),
+            "title": "Invite New Investigator",
+            "form": form,
+            "opts": self.model._meta,
+        }
+        return TemplateResponse(
+            request, "admin/users/user/create_invitation.html", context
+        )

--- a/backend/apps/users/forms.py
+++ b/backend/apps/users/forms.py
@@ -1,0 +1,39 @@
+from django import forms
+from django.core.exceptions import ValidationError
+
+from apps.users.models import User
+
+
+class InvestigatorInvitationForm(forms.Form):
+    """
+    A form for creating a new investigator invitation.
+
+    Validates that the username and email are unique before attempting to create the user.
+    """
+    username = forms.CharField(
+        label="Username",
+        max_length=150,
+        required=True,
+        help_text="Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.",
+    )
+    email = forms.EmailField(
+        label="Email Address",
+        required=True,
+        help_text="A valid email address for the investigator.",
+    )
+    first_name = forms.CharField(label="First Name", max_length=150, required=False)
+    last_name = forms.CharField(label="Last Name", max_length=150, required=False)
+
+    def clean_username(self):
+        """Ensure the username is not already taken."""
+        username = self.cleaned_data.get("username")
+        if User.objects.filter(username=username).exists():
+            raise ValidationError("A user with this username already exists.")
+        return username
+
+    def clean_email(self):
+        """Ensure the email is not already in use."""
+        email = self.cleaned_data.get("email")
+        if User.objects.filter(email=email).exists():
+            raise ValidationError("A user with this email address already exists.")
+        return email

--- a/backend/apps/users/services.py
+++ b/backend/apps/users/services.py
@@ -1,0 +1,63 @@
+import secrets
+from datetime import timedelta
+
+from django.db import transaction
+from django.utils import timezone
+
+from apps.users.models import OnboardingInvitation, User
+
+
+@transaction.atomic
+def create_investigator_invitation(
+    *, username: str, email: str, first_name: str = "", last_name: str = ""
+) -> str:
+    """
+    Creates an inactive investigator user and a secure, single-use onboarding invitation.
+
+    This function is atomic, ensuring that both the user and their invitation
+    are created successfully, or neither is.
+
+    Args:
+        username: The username for the new investigator.
+        email: The email address for the new investigator.
+        first_name: Optional first name.
+        last_name: Optional last name.
+
+    Returns:
+        The full, single-use onboarding URL for the new investigator.
+
+    Raises:
+        ValueError: If a user with the given username or email already exists.
+    """
+    if User.objects.filter(username=username).exists() or User.objects.filter(email=email).exists():
+        raise ValueError(f"A user with username '{username}' or email '{email}' already exists.")
+
+    # 1. Create an inactive user with an unusable password.
+    user = User.objects.create(
+        username=username,
+        email=email,
+        first_name=first_name,
+        last_name=last_name,
+        is_active=False,
+        is_caseworker=True,
+        onboarding_complete=False,
+    )
+    user.set_unusable_password()
+    user.save()
+
+    # 2. Generate a secure, URL-safe token and an expiration date.
+    token = secrets.token_urlsafe(32)
+    expires_at = timezone.now() + timedelta(days=7)
+
+    OnboardingInvitation.objects.create(
+        user=user,
+        token=token,
+        expires_at=expires_at,
+    )
+
+    # 3. Construct the full onboarding URL.
+    # TODO: This should ideally come from Django settings or site configuration.
+    frontend_base_url = "http://localhost:3000"
+    onboarding_url = f"{frontend_base_url}/onboard/{token}"
+
+    return onboarding_url

--- a/backend/apps/users/templates/admin/users/user/change_list.html
+++ b/backend/apps/users/templates/admin/users/user/change_list.html
@@ -1,0 +1,11 @@
+{% extends "admin/change_list.html" %}
+{% load i18n static %}
+
+{% block object-tools-items %}
+  {{ block.super }}
+  <li>
+    {% if invite_button %}
+      {{ invite_button|safe }}
+    {% endif %}
+  </li>
+{% endblock %}

--- a/backend/apps/users/templates/admin/users/user/create_invitation.html
+++ b/backend/apps/users/templates/admin/users/user/create_invitation.html
@@ -1,0 +1,36 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+
+{% block extrastyle %}{{ block.super }}
+  <link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+  <form method="post" novalidate>{% csrf_token %}
+    <div>
+      <fieldset class="module aligned">
+        <h2>{{ title }}</h2>
+        <p>
+          This form will create a new, inactive user account and generate a single-use, secure link
+          for them to complete their onboarding process.
+        </p>
+        {% for field in form %}
+          <div class="form-row">
+            {{ field.errors }}
+            {{ field.label_tag }}
+            {{ field }}
+            {% if field.help_text %}
+              <div class="help">{{ field.help_text|safe }}</div>
+            {% endif %}
+          </div>
+        {% endfor %}
+      </fieldset>
+
+      <div class="submit-row">
+        <input type="submit" value="Create Invitation" class="default">
+      </div>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "argon2-cffi>=25.1.0",
   "bcrypt>=4.3.0",
   "pyotp>=2.9.0",
+  "litellm==1.77.1"
 ]
 [dependency-groups]
 dev = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation != 'PyPy'",
@@ -1024,7 +1024,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.77.4"
+version = "1.77.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1035,22 +1035,15 @@ dependencies = [
     { name = "jinja2" },
     { name = "jsonschema" },
     { name = "openai" },
-    { name = "pondpond" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/b7/0d3c6dbcff3064238d123f90ae96764a85352f3f5caab6695a55007fd019/litellm-1.77.4.tar.gz", hash = "sha256:ce652e10ecf5b36767bfdf58e53b2802e22c3de383b03554e6ee1a4a66fa743d", size = 10330773, upload-time = "2025-09-24T17:52:44.876Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/65/71fe4851709fa4a612e41b80001a9ad803fea979d21b90970093fd65eded/litellm-1.77.1.tar.gz", hash = "sha256:76bab5203115efb9588244e5bafbfc07a800a239be75d8dc6b1b9d17394c6418", size = 10275745, upload-time = "2025-09-13T21:05:21.377Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/32/90f8587818d146d604ed6eec95f96378363fda06b14817399cc68853383e/litellm-1.77.4-py3-none-any.whl", hash = "sha256:66c2bb776f1e19ceddfa977a2bbf7f05e6f26c4b1fec8b2093bd171d842701b8", size = 9138493, upload-time = "2025-09-24T17:52:40.764Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dc/ff4f119cd4d783742c9648a03e0ba5c2b52fc385b2ae9f0d32acf3a78241/litellm-1.77.1-py3-none-any.whl", hash = "sha256:407761dc3c35fbcd41462d3fe65dd3ed70aac705f37cde318006c18940f695a0", size = 9067070, upload-time = "2025-09-13T21:05:18.078Z" },
 ]
-
-[[package]]
-name = "madoka"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/eb/95288b1c4aa541eb296a6271e3f8c7ece03b78923ac47dbe95d2287d9f5e/madoka-0.7.1.tar.gz", hash = "sha256:e258baa84fc0a3764365993b8bf5e1b065383a6ca8c9f862fb3e3e709843fae7", size = 81413, upload-time = "2019-02-10T18:38:01.382Z" }
 
 [[package]]
 name = "magicattr"
@@ -1405,18 +1398,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a5/f2/273fe54a78dc5c6c8dd63db71f5a6ceb95e4648516b5aeaeff4bde804e44/poethepoet-0.37.0.tar.gz", hash = "sha256:73edf458707c674a079baa46802e21455bda3a7f82a408e58c31b9f4fe8e933d", size = 68570, upload-time = "2025-08-11T18:00:29.103Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/92/1b/5337af1a6a478d25a3e3c56b9b4b42b0a160314e02f4a0498d5322c8dac4/poethepoet-0.37.0-py3-none-any.whl", hash = "sha256:861790276315abcc8df1b4bd60e28c3d48a06db273edd3092f3c94e1a46e5e22", size = 90062, upload-time = "2025-08-11T18:00:27.595Z" },
-]
-
-[[package]]
-name = "pondpond"
-version = "1.4.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "madoka" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/9b/8411458ca8ce8b5b9b135e4a19823f1caf958ca9985883db104323492982/pondpond-1.4.1.tar.gz", hash = "sha256:8afa34b869d1434d21dd2ec12644abc3b1733fcda8fcf355300338a13a79bb7b", size = 15237, upload-time = "2024-03-01T07:08:06.756Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/d4/f18d6985157cc68f76469480182cbee2a03a45858456955acf57f9dcbb4c/pondpond-1.4.1-py3-none-any.whl", hash = "sha256:641028ead4e8018ca6de1220c660ddd6d6fbf62a60e72f410655dd0451d82880", size = 14498, upload-time = "2024-03-01T07:08:04.63Z" },
 ]
 
 [[package]]
@@ -1935,6 +1916,7 @@ dependencies = [
     { name = "djangorestframework" },
     { name = "djangorestframework-simplejwt" },
     { name = "dspy" },
+    { name = "litellm" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pynacl" },
     { name = "pyotp" },
@@ -1967,6 +1949,7 @@ requires-dist = [
     { name = "djangorestframework", specifier = ">=3.16.1" },
     { name = "djangorestframework-simplejwt", specifier = ">=5.5.1" },
     { name = "dspy", specifier = ">=3.0.3" },
+    { name = "litellm", specifier = "==1.77.1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.10" },
     { name = "pynacl", specifier = ">=1.6.0" },
     { name = "pyotp", specifier = ">=2.9.0" },


### PR DESCRIPTION
This commit introduces a new workflow for inviting investigators to the platform directly from the Django admin interface.

A custom "Invite Investigator" button has been added to the User list view. This button leads to a form where an admin can enter the new investigator's details (username, email, etc.).

Upon submission, a unique, single-use onboarding link is generated and displayed to the admin to be shared securely with the new user.

The `OnboardingInvitation` model and its corresponding admin interface have been added to track the status of these invitations.

Includes the addition of the `litellm` dependency.